### PR TITLE
Fixes #11 - Write thumbnails of supported types only

### DIFF
--- a/sushichef.py
+++ b/sushichef.py
@@ -354,7 +354,7 @@ def save_thumbnail(url, title):
     else:
         img_buffer = BytesIO(r.content)
         img_ext = imghdr.what(img_buffer)
-        if img_ext != "gif":
+        if img_ext in ["jpeg", "png"]:
             filename = "{}.{}".format(title, img_ext)
             base_dir = build_path([DATA_DIR, DATA_DIR_SUBJECT, "thumbnails"])
             filepath = os.path.join(base_dir, filename)


### PR DESCRIPTION
This fixes #11 by allowing only supported thumbnail formats to be written